### PR TITLE
fix(search): regex bug when keyword contains the letter s

### DIFF
--- a/src/operator/search.ts
+++ b/src/operator/search.ts
@@ -8,7 +8,7 @@ export default function (
   tabular: Tabular<TCell>,
 ): Tabular<TCell> {
   // escape special regex chars
-  keyword = keyword.replace(/[-[\]{}()*+?.,\\^$|#\\s]/g, '\\$&');
+  keyword = keyword.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
 
   return new Tabular(
     tabular.rows.filter((row) =>

--- a/tests/operator/search.test.ts
+++ b/tests/operator/search.test.ts
@@ -9,7 +9,12 @@ describe('search', () => {
   const row2 = new Row([new Cell('foo'), new Cell('boo'), new Cell('bar')]);
   const row3 = new Row([new Cell('hello'), new Cell('test'), new Cell('!!!')]);
   const row4 = new Row([new Cell(null), new Cell('xkcd'), new Cell('???')]);
-  const tabular: Tabular<TCell> = new Tabular([row1, row2, row3, row4]);
+  const row5 = new Row([
+    new Cell('foo'),
+    new Cell('ping pong ping'),
+    new Cell('bar'),
+  ]);
+  const tabular: Tabular<TCell> = new Tabular([row1, row2, row3, row4, row5]);
 
   it('should work with exact match', () => {
     expect(search('hello', tabular).rows).toStrictEqual(
@@ -25,5 +30,17 @@ describe('search', () => {
 
   it('should return results with exact match', () => {
     expect(search('!!!', tabular).rows).toStrictEqual(new Tabular([row3]).rows);
+  });
+
+  it('should return results for a keyword with a space in', () => {
+    expect(search('ping pong', tabular).rows).toStrictEqual(
+      new Tabular([row5]).rows,
+    );
+  });
+
+  it('should return results for words with the letter s in', () => {
+    expect(search('test', tabular).rows).toStrictEqual(
+      new Tabular([row3]).rows,
+    );
   });
 });


### PR DESCRIPTION
Example: When searching for "Australia" it failed as it was actually searching for "Au\stralia".

Thanks!