### PR TITLE
Add a new way to paginate

### DIFF
--- a/packages/gridjs/src/config.ts
+++ b/packages/gridjs/src/config.ts
@@ -9,7 +9,7 @@ import Storage from './storage/storage';
 import Pipeline from './pipeline/pipeline';
 import Tabular from './tabular';
 import { Search, SearchConfig } from './view/plugin/search/search';
-import { Pagination, PaginationConfig } from './view/plugin/pagination';
+import { Pagination, PaginationConfig } from './view/plugin/pagination/pagination';
 import Header from './header';
 import { ServerStorageOptions } from './storage/server';
 import Dispatcher from './util/dispatcher';
@@ -201,9 +201,8 @@ export class Config {
       position: PluginPosition.Footer,
       component: Pagination,
       props: {
-        enabled:
-          userConfig.pagination === true ||
-          userConfig.pagination instanceof Object,
+        type: 'opaque-based',
+        enabled: userConfig.pagination === true || userConfig.pagination instanceof Object,
         ...(userConfig.pagination as PaginationConfig),
       },
     });

--- a/packages/gridjs/src/pipeline/processor.ts
+++ b/packages/gridjs/src/pipeline/processor.ts
@@ -24,10 +24,7 @@ interface PipelineProcessorEvents<T, P> {
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface PipelineProcessorProps {}
 
-export abstract class PipelineProcessor<
-  T,
-  P extends Partial<PipelineProcessorProps>
-> extends EventEmitter<PipelineProcessorEvents<T, P>> {
+export abstract class PipelineProcessor<T, P extends Partial<PipelineProcessorProps>> extends EventEmitter<PipelineProcessorEvents<T, P>> {
   public readonly id: ID;
   private readonly _props: P;
 

--- a/packages/gridjs/src/pipeline/transformer/arrayToTabular.ts
+++ b/packages/gridjs/src/pipeline/transformer/arrayToTabular.ts
@@ -9,6 +9,7 @@ class ArrayToTabularTransformer extends PipelineProcessor<Tabular, {}> {
 
   _process(arrayResponse: ArrayResponse): Tabular {
     const tabular = Tabular.fromArray(arrayResponse.data);
+    tabular.hasNextPage = arrayResponse.hasNextPage;
 
     // for server-side storage
     tabular.length = arrayResponse.total;

--- a/packages/gridjs/src/pipeline/transformer/storageResponseToArray.ts
+++ b/packages/gridjs/src/pipeline/transformer/storageResponseToArray.ts
@@ -11,6 +11,7 @@ import logger from '../../util/log';
 export interface ArrayResponse {
   data: TwoDArray<TCell>;
   total: number;
+  hasNextPage?: boolean;
 }
 
 interface StorageResponseToArrayTransformerProps
@@ -87,6 +88,7 @@ class StorageResponseToArrayTransformer extends PipelineProcessor<
     return {
       data: this.castData(storageResponse.data),
       total: storageResponse.total,
+      hasNextPage: storageResponse.hasNextPage
     };
   }
 }

--- a/packages/gridjs/src/plugin.ts
+++ b/packages/gridjs/src/plugin.ts
@@ -12,10 +12,7 @@ export interface PluginBaseProps<T extends PluginBaseComponentCtor> {
 /**
  * BaseComponent for all plugins
  */
-export abstract class PluginBaseComponent<
-  P extends PluginBaseProps<any> = any,
-  S = {}
-> extends BaseComponent<P, S> {}
+export abstract class PluginBaseComponent<P extends PluginBaseProps<any> = any, S = {} > extends BaseComponent<P, S> {}
 
 export interface PluginBaseComponentCtor<
   P extends PluginBaseProps<any> = any,

--- a/packages/gridjs/src/storage/memory.ts
+++ b/packages/gridjs/src/storage/memory.ts
@@ -14,7 +14,7 @@ class MemoryStorage extends Storage<TData> {
 
     return {
       data: data,
-      total: data.length,
+      total: data.length
     };
   }
 

--- a/packages/gridjs/src/storage/server.ts
+++ b/packages/gridjs/src/storage/server.ts
@@ -61,7 +61,6 @@ class ServerStorage extends Storage<ServerStorageOptions> {
     return fetch(opts.url, opts)
       .then(this.handler.bind(this))
       .then((res) => {
-        console.debug(`Has next page: ${opts.hasNextPage(res)}`);
         return {
           data: opts.then(res),
           total: typeof opts.total === 'function' ? opts.total(res) : undefined,

--- a/packages/gridjs/src/storage/server.ts
+++ b/packages/gridjs/src/storage/server.ts
@@ -12,7 +12,7 @@ export interface ServerStorageOptions extends RequestInit {
   // before calling the `then` function
   handle?: (response: Response) => Promise<any>;
   total?: (data: any) => number;
-  hasNextPage?: boolean;
+  hasNextPage?: (data: any) => boolean;
   // to bypass the current implementation of ServerStorage and process the
   // request manually (e.g. when user wants to connect their own SDK/HTTP Client)
   data?: (opts: ServerStorageOptions) => Promise<StorageResponse>;
@@ -61,10 +61,11 @@ class ServerStorage extends Storage<ServerStorageOptions> {
     return fetch(opts.url, opts)
       .then(this.handler.bind(this))
       .then((res) => {
+        console.debug(`Has next page: ${opts.hasNextPage(res)}`);
         return {
           data: opts.then(res),
           total: typeof opts.total === 'function' ? opts.total(res) : undefined,
-          hasNextPage: opts.hasNextPage
+          hasNextPage: opts.hasNextPage(res),
         };
       });
   }

--- a/packages/gridjs/src/storage/server.ts
+++ b/packages/gridjs/src/storage/server.ts
@@ -12,6 +12,7 @@ export interface ServerStorageOptions extends RequestInit {
   // before calling the `then` function
   handle?: (response: Response) => Promise<any>;
   total?: (data: any) => number;
+  hasNextPage?: boolean;
   // to bypass the current implementation of ServerStorage and process the
   // request manually (e.g. when user wants to connect their own SDK/HTTP Client)
   data?: (opts: ServerStorageOptions) => Promise<StorageResponse>;
@@ -63,6 +64,7 @@ class ServerStorage extends Storage<ServerStorageOptions> {
         return {
           data: opts.then(res),
           total: typeof opts.total === 'function' ? opts.total(res) : undefined,
+          hasNextPage: opts.hasNextPage
         };
       });
   }

--- a/packages/gridjs/src/storage/storage.ts
+++ b/packages/gridjs/src/storage/storage.ts
@@ -21,6 +21,7 @@ abstract class Storage<I> {
 export interface StorageResponse {
   data: TData;
   total: number;
+  hasNextPage?: boolean;
 }
 
 export default Storage;

--- a/packages/gridjs/src/tabular.ts
+++ b/packages/gridjs/src/tabular.ts
@@ -7,6 +7,7 @@ import { oneDtoTwoD } from './util/array';
 class Tabular extends Base {
   private _rows: Row[];
   private _length: number;
+  private _hasNextPage: boolean;
 
   constructor(rows?: Row[] | Row) {
     super();
@@ -30,6 +31,14 @@ class Tabular extends Base {
 
   get length(): number {
     return this._length || this.rows.length;
+  }
+
+  get hasNextPage(): boolean {
+    return this._hasNextPage;
+  }
+
+  set hasNextPage(hasNextPage: boolean) {
+    this._hasNextPage = hasNextPage;
   }
 
   // we want to sent the length when storage is ServerStorage

--- a/packages/gridjs/src/view/plugin/pagination.tsx
+++ b/packages/gridjs/src/view/plugin/pagination.tsx
@@ -10,6 +10,7 @@ interface PaginationState {
   page: number;
   limit?: number;
   total: number;
+  hasNextPage: boolean;
 }
 
 export interface PaginationConfig {
@@ -51,6 +52,7 @@ export class Pagination extends PluginBaseComponent<
       limit: props.limit,
       page: props.page || 0,
       total: 0,
+      hasNextPage: false
     };
   }
 
@@ -90,6 +92,7 @@ export class Pagination extends PluginBaseComponent<
         this.setState({
           total: 0,
           page: 0,
+          hasNextPage: false
         });
       });
     }
@@ -261,7 +264,7 @@ export class Pagination extends PluginBaseComponent<
           {this.props.nextButton && (
             <button
               tabIndex={0}
-              disabled={this.pages === this.state.page + 1 || this.pages === 0}
+              disabled={!this.state.hasNextPage}
               onClick={this.setPage.bind(this, this.state.page + 1)}
             >
               {this._('pagination.next')}

--- a/packages/gridjs/src/view/plugin/pagination/paginationType.ts
+++ b/packages/gridjs/src/view/plugin/pagination/paginationType.ts
@@ -1,0 +1,1 @@
+export type PaginationType = "opaque-based" | "offset-based";

--- a/packages/gridjs/src/view/plugin/search/search.tsx
+++ b/packages/gridjs/src/view/plugin/search/search.tsx
@@ -19,9 +19,7 @@ export interface SearchConfig {
   };
 }
 
-export class Search extends PluginBaseComponent<
-  SearchConfig & PluginBaseProps<Search>
-> {
+export class Search extends PluginBaseComponent<SearchConfig & PluginBaseProps<Search>> {
   private readonly searchProcessor:
     | GlobalSearchFilter
     | ServerGlobalSearchFilter;

--- a/packages/gridjs/tests/config.test.ts
+++ b/packages/gridjs/tests/config.test.ts
@@ -2,7 +2,7 @@ import { Config } from '../src/config';
 import Storage from '../src/storage/storage';
 import { Translator } from '../src/i18n/language';
 import { Search } from '../src/view/plugin/search/search';
-import { Pagination } from '../src/view/plugin/pagination';
+import { Pagination } from '../src/view/plugin/pagination/pagination';
 
 describe('Config', () => {
   let config: Config = null;

--- a/packages/gridjs/tsconfig.release.json
+++ b/packages/gridjs/tsconfig.release.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": ".",
-    "removeComments": true
+    "removeComments": true,
+    "outDir": "dist"
   },
   "include": [
     "index.ts",


### PR DESCRIPTION
This partially merges pagination in the core of the library by adding a new property to the `Tabular` class which is `hasNextPage`. 
The commit also introduces a new property to `PaginationConfig`: 
```typescript 
type: PaginationType
```
which accepts to values:
```typescript
export type PaginationType = "opaque-based" | "offset-based";
```
They are the two pagination types. 
**offset-based** is already provided by Gridjs natively and needs the `total` property in the `server`'s one to work.
**opaque-based** is the new one and it works by changing the property `total` by `hasNextPage` one. It has the same signature (`hasNextPage: (data) => boolean`).

By enabling **opaque-based** pagination using the `type` property, Gridjs will skip automatically `renderPages` and `renderSummary` since this pagination type, usually, relies on "next page tokens" and the pattern does not provide information about how many pages are left or the total count of entries in the server.

**NOTE: opaque-based** pagination is enabled by default.

The normal behavior of Gridjs pagination can be enabled by switching `type` to **offset-based**.