### PR TITLE
Add plugins config property

### DIFF
--- a/packages/gridjs/src/config.ts
+++ b/packages/gridjs/src/config.ts
@@ -20,7 +20,7 @@ import StorageUtils from './storage/storageUtils';
 import PipelineUtils from './pipeline/pipelineUtils';
 import { EventEmitter } from './util/eventEmitter';
 import { GridEvents } from './events';
-import { PluginManager, PluginPosition } from './plugin';
+import { PluginManager, PluginPosition, Plugin } from './plugin';
 import Grid from './grid';
 
 // Config type used internally
@@ -82,6 +82,7 @@ export interface Config {
     notfound: string;
     error: string;
   }>;
+  plugins?: Plugin<any>[]
 }
 
 // Config type used by the consumers
@@ -220,6 +221,11 @@ export class Config {
         ...(userConfig.pagination as PaginationConfig),
       },
     });
+
+    // Additional plugins
+    if (config.plugins) {
+      config.plugins.forEach((p: Plugin<any>) => config.plugin.add(p))
+    }
 
     return config;
   }

--- a/packages/gridjs/tests/plugin.test.tsx
+++ b/packages/gridjs/tests/plugin.test.tsx
@@ -169,4 +169,21 @@ describe('Plugin', () => {
 
     expect(renderer.html()).toMatchSnapshot();
   });
+
+  it('should create a userConfig with custom plugin', () => {
+    const config = Config.fromUserConfig({
+      data: [[1, 2, 3]],
+      plugins: [{
+        id: 'dummyheader',
+        position: PluginPosition.Header,
+        component: DummyPlugin,
+        props: { text: 'dummyheader' },
+      }]
+    });
+
+    expect(config.plugin.get('dummyheader')).toMatchObject({
+      id: 'dummyheader',
+      position: PluginPosition.Header
+    });
+  });
 });


### PR DESCRIPTION
This adds a config property `plugins` that allows adding plugins through the constructor of the grid.  