### PR TITLE
Search ignore content of hidden columns

### DIFF
--- a/packages/gridjs/src/config.ts
+++ b/packages/gridjs/src/config.ts
@@ -209,6 +209,7 @@ export class Config {
         enabled:
           userConfig.search === true || userConfig.search instanceof Object,
         ...(userConfig.search as SearchConfig),
+        columns: userConfig.columns
       },
     });
 

--- a/packages/gridjs/src/operator/search.ts
+++ b/packages/gridjs/src/operator/search.ts
@@ -1,10 +1,11 @@
 import Tabular from '../tabular';
-import { VNode } from 'preact';
+import { ComponentChild, VNode } from 'preact';
 import { HTMLContentProps } from '../view/htmlElement';
-import { TCell } from '../types';
+import { OneDArray, TCell, TColumn } from '../types';
 
 export default function (
   keyword: string,
+  columns: OneDArray<TColumn | string | ComponentChild>,
   tabular: Tabular,
   selector?: (cell: TCell, rowIndex: number, cellIndex: number) => string,
 ): Tabular {
@@ -16,6 +17,13 @@ export default function (
       row.cells.some((cell, cellIndex) => {
         if (!cell) {
           return false;
+        }
+
+        if (columns && columns[cellIndex] && typeof columns[cellIndex] === 'object') {
+          const typedColumn = columns[cellIndex] as TColumn;
+          if (typedColumn.hidden) {
+            return false;
+          }
         }
 
         let data = '';

--- a/packages/gridjs/src/pipeline/filter/globalSearch.ts
+++ b/packages/gridjs/src/pipeline/filter/globalSearch.ts
@@ -5,10 +5,12 @@ import {
   PipelineProcessorProps,
   ProcessorType,
 } from '../processor';
-import { TCell } from '../../types';
+import { OneDArray, TCell, TColumn } from '../../types';
+import { ComponentChild } from "preact";
 
 interface GlobalSearchFilterProps extends PipelineProcessorProps {
   keyword: string;
+  columns: OneDArray<TColumn | string | ComponentChild>;
   selector?: (cell: TCell, rowIndex: number, cellIndex: number) => string;
 }
 
@@ -24,6 +26,7 @@ class GlobalSearchFilter extends PipelineProcessor<
     if (this.props.keyword) {
       return search(
         String(this.props.keyword).trim(),
+        this.props.columns,
         data,
         this.props.selector,
       );

--- a/packages/gridjs/src/view/plugin/search/search.tsx
+++ b/packages/gridjs/src/view/plugin/search/search.tsx
@@ -1,11 +1,11 @@
-import { h } from 'preact';
+import { ComponentChild, h } from 'preact';
 import GlobalSearchFilter from '../../../pipeline/filter/globalSearch';
 import { classJoin, className } from '../../../util/className';
 import { SearchStore, SearchStoreState } from './store';
 import { SearchActions } from './actions';
 import ServerGlobalSearchFilter from '../../../pipeline/filter/serverGlobalSearch';
 import { debounce } from '../../../util/debounce';
-import { TCell } from '../../../types';
+import { OneDArray, TCell, TColumn } from '../../../types';
 import { PluginBaseComponent, PluginBaseProps } from '../../../plugin';
 
 export interface SearchConfig {
@@ -13,6 +13,7 @@ export interface SearchConfig {
   enabled?: boolean;
   debounceTimeout?: number;
   selector?: (cell: TCell, rowIndex: number, cellIndex: number) => string;
+  columns?: OneDArray<TColumn | string | ComponentChild>;
   server?: {
     url?: (prevUrl: string, keyword: string) => string;
     body?: (prevBody: BodyInit, keyword: string) => BodyInit;
@@ -57,6 +58,7 @@ export class Search extends PluginBaseComponent<
       } else {
         searchProcessor = new GlobalSearchFilter({
           keyword: props.keyword,
+          columns: props.columns,
           selector: props.selector,
         });
       }

--- a/packages/gridjs/tests/operator/search.test.ts
+++ b/packages/gridjs/tests/operator/search.test.ts
@@ -4,10 +4,15 @@ import Row from '../../src/row';
 import search from '../../src/operator/search';
 
 describe('search', () => {
-  const row1 = new Row([new Cell('hello'), new Cell('world'), new Cell('!')]);
-  const row2 = new Row([new Cell('foo'), new Cell('boo'), new Cell('bar')]);
-  const row3 = new Row([new Cell('hello'), new Cell('test'), new Cell('!!!')]);
-  const row4 = new Row([new Cell(null), new Cell('xkcd'), new Cell('???')]);
+  const column1 = "col1";
+  const column2 = { id: "col2", name: "col2" };
+  const column3 = { id: "col3", name: "col3" };
+  const column4 = { id: "col4", name: "col4", hidden: true };
+  const columns = [column1, column2, column3, column4];
+  const row1 = new Row([new Cell('hello'), new Cell('world'), new Cell('!'), new Cell('hidden content')]);
+  const row2 = new Row([new Cell('foo'), new Cell('boo'), new Cell('bar'), new Cell('hidden content')]);
+  const row3 = new Row([new Cell('hello'), new Cell('test'), new Cell('!!!'), new Cell('hidden content')]);
+  const row4 = new Row([new Cell(null), new Cell('xkcd'), new Cell('???'), new Cell('hidden content')]);
   const row5 = new Row([
     new Cell('foo'),
     new Cell('ping pong ping'),
@@ -16,35 +21,35 @@ describe('search', () => {
   const tabular: Tabular = new Tabular([row1, row2, row3, row4, row5]);
 
   it('should work with exact match', () => {
-    expect(search('hello', tabular).rows).toStrictEqual(
+    expect(search('hello', columns, tabular).rows).toStrictEqual(
       new Tabular([row1, row3]).rows,
     );
   });
 
   it('should return results with partial keyword', () => {
-    expect(search('h', tabular).rows).toStrictEqual(
+    expect(search('h', columns, tabular).rows).toStrictEqual(
       new Tabular([row1, row3]).rows,
     );
   });
 
   it('should return results with exact match', () => {
-    expect(search('!!!', tabular).rows).toStrictEqual(new Tabular([row3]).rows);
+    expect(search('!!!', columns, tabular).rows).toStrictEqual(new Tabular([row3]).rows);
   });
 
   it('should return results for a keyword with a space in', () => {
-    expect(search('ping pong', tabular).rows).toStrictEqual(
+    expect(search('ping pong', columns, tabular).rows).toStrictEqual(
       new Tabular([row5]).rows,
     );
   });
 
   it('should return results for words with the letter s in', () => {
-    expect(search('test', tabular).rows).toStrictEqual(
+    expect(search('test', columns, tabular).rows).toStrictEqual(
       new Tabular([row3]).rows,
     );
   });
 
   it('should use the selector with hardcoded string', () => {
-    expect(search('test', tabular, () => 'custom keyword').rows).toStrictEqual(
+    expect(search('test', columns, tabular, () => 'custom keyword').rows).toStrictEqual(
       new Tabular([]).rows,
     );
   });
@@ -53,9 +58,16 @@ describe('search', () => {
     expect(
       search(
         '00',
+        columns,
         tabular,
         (_, rowIndex, cellIndex) => `${rowIndex}${cellIndex}`,
       ).rows,
     ).toStrictEqual(new Tabular([row1]).rows);
+  });
+
+  it('should ignore content of hidden columns', () => {
+    expect(search('hidden', columns, tabular).rows).toStrictEqual(
+      new Tabular([]).rows,
+    );
   });
 });


### PR DESCRIPTION
Goal of this pull request is to change the behavior of search plugin with hidden columns.

Currently, when typing a keyword, search plugin look for all cells including hidden one. It make the result a little bit strange to the final user seeing rows that does not contains his keyword.

This change only applies to in memory data (not server side).