### PR TITLE
Fix spelling and grammatical errors

### DIFF
--- a/l10n/es_ES.ts
+++ b/l10n/es_ES.ts
@@ -1,6 +1,6 @@
 export default {
   search: {
-    placeholder: '🔍 Busqueda...',
+    placeholder: 'Buscar...',
   },
   sort: {
     sortAsc: 'Ordenar la columna en orden ascendente',
@@ -11,12 +11,12 @@ export default {
     next: 'Siguiente',
     navigate: (page, pages) => `Página ${page} de ${pages}`,
     page: (page) => `Página ${page}`,
-    showing: 'Mostrando los resultados',
-    of: 'sobre',
-    to: 'a',
-    results: '',
+    showing: 'Mostrando registros del',
+    of: 'de un total de',
+    to: 'al',
+    results: 'registros',
   },
   loading: 'Cargando...',
-  noRecordsFound: 'Nigún resultado encontrado',
+  noRecordsFound: 'No se encontraron registros',
   error: 'Se produjo un error al recuperar datos',
 };


### PR DESCRIPTION
Some spelling and grammatical errors were found in the Spanish translations.

For example: 
The word "Nigún" is missing the letter "n" and "Busqueda" is missing the accent on the letter "u".

New translations are proposed for the keys "showing", "of", "to" and "results", since the current ones do not make sense.