### PR TITLE
Fixed focus outline

### DIFF
--- a/src/theme/mermaid/pagination.scss
+++ b/src/theme/mermaid/pagination.scss
@@ -28,6 +28,9 @@
 
     button:focus {
       box-shadow: 0 0 0 2px rgba(149, 189, 243, 0.5);
+      position: relative;
+      margin-right: -1px;
+      border-right: 1px solid $gray4;
     }
 
     button:hover {
@@ -64,6 +67,10 @@
     button:first-child {
       border-bottom-left-radius: 6px;
       border-top-left-radius: 6px;
+    }
+    
+    button:last-child:focus {
+      margin-right: 0;
     }
   }
 }


### PR DESCRIPTION
Fixed the outline, which should be around the whole button and not be clipped on the right, for each of the buttons. See difference:

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td>
      <img width="500px" src="https://user-images.githubusercontent.com/2801252/172035186-37b0d715-e583-4a0b-8b3d-faaa0386fef5.gif" />
    </td>
    <td>
      <img width="500px" src="https://user-images.githubusercontent.com/2801252/172035181-4fab14cd-e134-4ecc-b27f-e2c6b89a252a.gif" />
    </td>
  </tr>
</table>

The margin right -1 fixes that adding a right border would move the item otherwise.

The last-child fixes that there's no need for margin -1 on the last child since it already has a border on the right, so to keep it in place there's no need to move it.