### PR TITLE
fix: remove the TD data type warning

### DIFF
--- a/src/view/table/td.tsx
+++ b/src/view/table/td.tsx
@@ -7,7 +7,6 @@ import Row from '../../row';
 import { JSXInternal } from 'preact/src/jsx';
 import { PluginRenderer } from '../../plugin';
 import { useConfig } from '../../hooks/useConfig';
-import log from '../../util/log';
 
 export function TD(
   props: {

--- a/src/view/table/td.tsx
+++ b/src/view/table/td.tsx
@@ -38,12 +38,6 @@ export function TD(
       );
     }
 
-    if (typeof props.cell.data === 'object') {
-      log.warn(
-        `The data field for cell ${props.cell.id} is not a primitive value. Did you mean to add a "formatter" function to this column?`,
-      );
-    }
-
     return props.cell.data;
   };
 


### PR DESCRIPTION
Remove the cell data type console.warning because a TD should be able render Preact class components (e.g. `html(...)`). Fixes #1288