### PR TITLE
fix: export the useTranslator hook

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,7 @@ import Cell from './src/cell';
 import { useConfig } from './src/hooks/useConfig';
 import { useStore } from './src/hooks/useStore';
 import useSelector from './src/hooks/useSelector';
+import { useTranslator } from 'src/i18n/language';
 
 export {
   Grid,
@@ -31,4 +32,5 @@ export {
   useConfig,
   useState,
   useSelector,
+  useTranslator,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gridjs",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gridjs",
-      "version": "6.0.5",
+      "version": "6.0.6",
       "license": "MIT",
       "dependencies": {
         "preact": "^10.11.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridjs",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "description": "Advanced table plugin",
   "author": "Afshin Mehrabani <afshin.meh@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
To export the `useTranslator` hook which can be used in plugins.