### PR TITLE
Save width when resized and remember after refresh

### DIFF
--- a/plugins/selection/package-lock.json
+++ b/plugins/selection/package-lock.json
@@ -5,116 +5,42 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "selection",
       "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "gridjs": "../../"
       }
     },
-    "../..": {
-      "version": "5.0.2",
+    "node_modules/gridjs": {
+      "version": "6.0.6",
+      "resolved": "file:../..",
       "license": "MIT",
       "dependencies": {
-        "preact": "^10.5.12",
-        "tslib": "^2.0.1"
-      },
-      "devDependencies": {
-        "@types/enzyme": "^3.10.5",
-        "@types/jest": "^26.0.0",
-        "@types/jest-axe": "^3.2.2",
-        "@types/node": "^15.3.0",
-        "@typescript-eslint/eslint-plugin": "~4.28.0",
-        "@typescript-eslint/parser": "~4.28.0",
-        "autoprefixer": "^9.8.0",
-        "axe-core": "^4.0.0",
-        "check-export-map": "^1.1.1",
-        "cssnano": "^5.0.5",
-        "cypress": "^7.4.0",
-        "cypress-visual-regression": "^1.5.7",
-        "enzyme": "^3.11.0",
-        "enzyme-adapter-preact-pure": "^3.0.0",
-        "eslint": "~7.29.0",
-        "eslint-config-prettier": "^6.11.0",
-        "eslint-plugin-jest": "~24.3.2",
-        "identity-obj-proxy": "^3.0.0",
-        "jest": "~27.0.6",
-        "jest-axe": "^5.0.1",
-        "jest-extended": "^0.11.5",
-        "jsdom": "^16.2.2",
-        "jsdom-global": "^3.0.2",
-        "lerna-changelog": "^1.0.1",
-        "microbundle": "^0.13.0",
-        "node-sass": "^6.0.1",
-        "node-sass-chokidar": "^1.5.0",
-        "npm-run-all": "^4.1.5",
-        "postcss": "^8.3.0",
-        "postcss-cli": "^8.3.1",
-        "postcss-nested": "^5.0.5",
-        "postcss-scss": "^4.0.0",
-        "postcss-sort-media-queries": "^3.10.11",
-        "prettier": "~2.3.1",
-        "rimraf": "~3.0.2",
-        "source-map-loader": "^2.0.1",
-        "start-server-and-test": "^1.12.3",
-        "ts-jest": "^27.0.3",
-        "ts-loader": "^9.1.1",
-        "tsutils": "~3.21.0",
-        "typescript": "^4.2.4"
+        "preact": "^10.11.3"
       }
     },
-    "node_modules/gridjs": {
-      "resolved": "../..",
-      "link": true
+    "node_modules/preact": {
+      "version": "10.13.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.13.0.tgz",
+      "integrity": "sha512-ERdIdUpR6doqdaSIh80hvzebHB7O6JxycOhyzAeLEchqOq/4yueslQbfnPwXaNhAYacFTyCclhwkEbOumT0tHw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
     }
   },
   "dependencies": {
     "gridjs": {
-      "version": "file:../..",
+      "version": "6.0.6",
       "requires": {
-        "@types/enzyme": "^3.10.5",
-        "@types/jest": "^26.0.0",
-        "@types/jest-axe": "^3.2.2",
-        "@types/node": "^15.3.0",
-        "@typescript-eslint/eslint-plugin": "~4.28.0",
-        "@typescript-eslint/parser": "~4.28.0",
-        "autoprefixer": "^9.8.0",
-        "axe-core": "^4.0.0",
-        "check-export-map": "^1.1.1",
-        "cssnano": "^5.0.5",
-        "cypress": "^7.4.0",
-        "cypress-visual-regression": "^1.5.7",
-        "enzyme": "^3.11.0",
-        "enzyme-adapter-preact-pure": "^3.0.0",
-        "eslint": "~7.29.0",
-        "eslint-config-prettier": "^6.11.0",
-        "eslint-plugin-jest": "~24.3.2",
-        "identity-obj-proxy": "^3.0.0",
-        "jest": "~27.0.6",
-        "jest-axe": "^5.0.1",
-        "jest-extended": "^0.11.5",
-        "jsdom": "^16.2.2",
-        "jsdom-global": "^3.0.2",
-        "lerna-changelog": "^1.0.1",
-        "microbundle": "^0.13.0",
-        "node-sass": "^6.0.1",
-        "node-sass-chokidar": "^1.5.0",
-        "npm-run-all": "^4.1.5",
-        "postcss": "^8.3.0",
-        "postcss-cli": "^8.3.1",
-        "postcss-nested": "^5.0.5",
-        "postcss-scss": "^4.0.0",
-        "postcss-sort-media-queries": "^3.10.11",
-        "preact": "^10.5.12",
-        "prettier": "~2.3.1",
-        "rimraf": "~3.0.2",
-        "source-map-loader": "^2.0.1",
-        "start-server-and-test": "^1.12.3",
-        "ts-jest": "^27.0.3",
-        "ts-loader": "^9.1.1",
-        "tslib": "^2.0.1",
-        "tsutils": "~3.21.0",
-        "typescript": "^4.2.4"
+        "preact": "^10.11.3"
       }
+    },
+    "preact": {
+      "version": "10.13.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.13.0.tgz",
+      "integrity": "sha512-ERdIdUpR6doqdaSIh80hvzebHB7O6JxycOhyzAeLEchqOq/4yueslQbfnPwXaNhAYacFTyCclhwkEbOumT0tHw=="
     }
   }
 }

--- a/src/grid.ts
+++ b/src/grid.ts
@@ -6,10 +6,12 @@ import { EventEmitter } from './util/eventEmitter';
 import { GridEvents } from './events';
 import { PluginManager } from './plugin';
 import { ConfigContext } from './config';
+import {xPath} from "./util/xpath";
 
 class Grid extends EventEmitter<GridEvents> {
   public config: Config;
   public plugin: PluginManager;
+  public uniqueIdentifier: string; // this is used in order to have different column widths (saved in localstorage) for different pages and configurations, this way you can have multiple tables, routes, ...
 
   constructor(config?: Partial<Config>) {
     super();
@@ -82,6 +84,20 @@ class Grid extends EventEmitter<GridEvents> {
 
     this.config.container = container;
     render(this.createElement(), container);
+
+    const newUniqueIdentifier = xPath(this.config.container, true) + window.location.host + window.location.pathname; // use xpath of container because that will be unique for every table on the same page
+
+    if (this.uniqueIdentifier) {
+      // transfer all column widths to new key (because identifier changed)
+
+      const storage = {...window.localStorage};
+      for (const item in storage) {
+        window.localStorage.setItem(newUniqueIdentifier + item.split(this.uniqueIdentifier)[1], storage[item]);
+        window.localStorage.removeItem(item);
+      }
+    }
+
+    this.uniqueIdentifier = newUniqueIdentifier;
 
     return this;
   }

--- a/src/util/xpath.ts
+++ b/src/util/xpath.ts
@@ -1,0 +1,127 @@
+export const xPath = function(node, optimized) {
+  if (node.nodeType === 9) {
+    return '/';
+  }
+
+  const steps = [];
+
+  while (node) {
+    const step = xPathValue(node, optimized);
+    if (!step) {
+      break;
+    }  // Error - bail out early.
+    steps.push(step);
+    if (step.optimized) {
+      break;
+    }
+    node = node.parentNode;
+  }
+
+  steps.reverse();
+  return (steps.length && steps[0].optimized ? '' : '/') + steps.join('/');
+};
+
+const xPathValue = function(node, optimized) {
+  let ownValue;
+  const ownIndex = xPathIndex(node);
+  if (ownIndex === -1) {
+    return null;
+  }  // Error.
+
+  switch (node.nodeType) {
+    case 1:
+      if (optimized && node.getAttribute('id')) {
+        return new Step('//*[@id="' + node.getAttribute('id') + '"]', true);
+      }
+      ownValue = node.localName;
+      break;
+    case 2:
+      ownValue = '@' + node.nodeName;
+      break;
+    case 3:
+    case 4:
+      ownValue = 'text()';
+      break;
+    case 7:
+      ownValue = 'processing-instruction()';
+      break;
+    case 8:
+      ownValue = 'comment()';
+      break;
+    case 9:
+      ownValue = '';
+      break;
+    default:
+      ownValue = '';
+      break;
+  }
+
+  if (ownIndex > 0) {
+    ownValue += '[' + ownIndex + ']';
+  }
+
+  return new Step(ownValue, node.nodeType === 9);
+};
+
+const xPathIndex = function(node) {
+  /**
+   * Returns -1 in case of error, 0 if no siblings matching the same expression,
+   * <XPath index among the same expression-matching sibling nodes> otherwise.
+   */
+  function areNodesSimilar(left, right) {
+    if (left === right) {
+      return true;
+    }
+
+    if (left.nodeType === 1 && right.nodeType === 1) {
+      return left.localName === right.localName;
+    }
+
+    if (left.nodeType === right.nodeType) {
+      return true;
+    }
+
+    // XPath treats CDATA as text nodes.
+    const leftType = left.nodeType === 4 ? 3 : left.nodeType;
+    const rightType = right.nodeType === 4 ? 3 : right.nodeType;
+    return leftType === rightType;
+  }
+
+  const siblings = node.parentNode ? node.parentNode.children : null;
+  if (!siblings) {
+    return 0;
+  }  // Root node - no siblings.
+  let hasSameNamedElements;
+  for (let i = 0; i < siblings.length; ++i) {
+    if (areNodesSimilar(node, siblings[i]) && siblings[i] !== node) {
+      hasSameNamedElements = true;
+      break;
+    }
+  }
+  if (!hasSameNamedElements) {
+    return 0;
+  }
+  let ownIndex = 1;  // XPath indices start with 1.
+  for (let i = 0; i < siblings.length; ++i) {
+    if (areNodesSimilar(node, siblings[i])) {
+      if (siblings[i] === node) {
+        return ownIndex;
+      }
+      ++ownIndex;
+    }
+  }
+  return -1;  // An error occurred: |node| not found in parent's children.
+};
+
+export class Step {
+  value: string;
+  optimized: boolean;
+  constructor(value: string, optimized: boolean) {
+    this.value = value;
+    this.optimized = optimized || false;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}

--- a/src/view/plugin/resize/resize.tsx
+++ b/src/view/plugin/resize/resize.tsx
@@ -38,7 +38,9 @@ export function Resize(props: {
     const thElement = props.thRef.current;
 
     if (offsetStart + getPageX(e) >= parseInt(thElement.style.minWidth, 10)) {
-      thElement.style.width = `${offsetStart + getPageX(e)}px`;
+      const width = offsetStart + getPageX(e);
+      thElement.style.width = `${width}px`;
+      localStorage.setItem(`columnWidth${props.column.id}`, width.toString()); // save column width in local storage
     }
   };
 

--- a/src/view/plugin/resize/resize.tsx
+++ b/src/view/plugin/resize/resize.tsx
@@ -2,11 +2,14 @@ import { h, RefObject } from 'preact';
 import { classJoin, className } from '../../../util/className';
 import { TColumn } from '../../../types';
 import { throttle } from '../../../util/throttle';
+import {useConfig} from "../../../hooks/useConfig";
 
 export function Resize(props: {
   column: TColumn;
   thRef: RefObject<HTMLTableCellElement>;
 }) {
+  const config = useConfig();
+
   let moveFn: (e) => void;
 
   const getPageX = (e: MouseEvent | TouchEvent) => {
@@ -40,7 +43,7 @@ export function Resize(props: {
     if (offsetStart + getPageX(e) >= parseInt(thElement.style.minWidth, 10)) {
       const width = offsetStart + getPageX(e);
       thElement.style.width = `${width}px`;
-      localStorage.setItem(`columnWidth${props.column.id}`, width.toString()); // save column width in local storage
+      localStorage.setItem(`${config.instance.uniqueIdentifier}${props.column.id}`, width.toString()); // save column width in local storage
     }
   };
 

--- a/src/view/table/th.tsx
+++ b/src/view/table/th.tsx
@@ -35,16 +35,16 @@ export function TH(
     }
 
     if (thRef.current && isResizable()) {
-      const width = localStorage.getItem(`columnWidth${props.column.id}`); // get column width from local storage
+      const width = localStorage.getItem(`${config.instance.uniqueIdentifier}${props.column.id}`); // get column width from local storage
       if (width && !isNaN(Number(width))) {
-        thRef.current.style.width = `${width}px`;
+        thRef.current.style.width = `${width}`;
       }
       else {
-        thRef.current.style.width = `${props.column.width}px`;
+        thRef.current.style.width = `${props.column.width}`;
       }
     }
     else if (thRef.current) {
-      thRef.current.style.width = `${props.column.width}px`;
+      thRef.current.style.width = `${props.column.width}`;
     }
   }, [thRef]);
 

--- a/src/view/table/th.tsx
+++ b/src/view/table/th.tsx
@@ -33,11 +33,18 @@ export function TH(
         });
       }
     }
+
     if (thRef.current && isResizable()) {
       const width = localStorage.getItem(`columnWidth${props.column.id}`); // get column width from local storage
-      if (width) {
+      if (width && !isNaN(Number(width))) {
         thRef.current.style.width = `${width}px`;
       }
+      else {
+        thRef.current.style.width = `${props.column.width}px`;
+      }
+    }
+    else if (thRef.current) {
+      thRef.current.style.width = `${props.column.width}px`;
     }
   }, [thRef]);
 
@@ -116,7 +123,6 @@ export function TH(
         ...config.style.th,
         ...{
           minWidth: props.column.minWidth,
-          width: props.column.width,
         },
         ...style,
         ...props.style,

--- a/src/view/table/th.tsx
+++ b/src/view/table/th.tsx
@@ -33,6 +33,12 @@ export function TH(
         });
       }
     }
+    if (thRef.current && isResizable()) {
+      const width = localStorage.getItem(`columnWidth${props.column.id}`); // get column width from local storage
+      if (width) {
+        thRef.current.style.width = `${width}px`;
+      }
+    }
   }, [thRef]);
 
   const isSortable = (): boolean => props.column.sort != undefined;


### PR DESCRIPTION
This way when a user refreshes the page the columns will keep the width he/she set it to.
Some applications refresh quite a lot and this way the user doesn't have to re-resize all the columns like he/she wants.

This works for different tables and different pages.