### PR TITLE
Correctly set page prop back to 0 when resetPageOnUpdate is enabled

### DIFF
--- a/src/view/plugin/pagination.tsx
+++ b/src/view/plugin/pagination.tsx
@@ -86,9 +86,11 @@ export function Pagination() {
     if (resetPageOnUpdate && updatedProcessor !== processor.current) {
       setCurrentPage(0);
       
-      processor.current.setProps({
-        page: 0,
-      });
+      if (processor.current.props.page !== 0) {
+        processor.current.setProps({
+          page: 0,
+        });
+      }
     }
   };
 

--- a/src/view/plugin/pagination.tsx
+++ b/src/view/plugin/pagination.tsx
@@ -85,6 +85,10 @@ export function Pagination() {
     // when a processor is updated for some reason
     if (resetPageOnUpdate && updatedProcessor !== processor.current) {
       setCurrentPage(0);
+      
+      processor.current.setProps({
+        page: 0,
+      });
     }
   };
 


### PR DESCRIPTION
Otherwise if there is a server side search while we're on a page other than 0, the current page is set back to 0 but the prop retains its old value. Causing issues with server side pagination as the page number that the server receives is different from the one the client is displaying.

Fixes #1311 