### PR TITLE
Fix broken getting started link

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Piece of :cake:
 ## Getting Started
 
 - [Install](https://gridjs.io/docs/install)
-- [Getting Started](https://gridjs.io/docs/index)
+- [Getting Started](https://gridjs.io/docs/)
 - [Examples](https://gridjs.io/docs/examples/hello-world)
 
 ## Documentation :book:


### PR DESCRIPTION
This could point to /docs/hello-world as well but the root of docs seemed a great place to get started.