### PR TITLE
fix: made search input an uncontrolled component

### DIFF
--- a/src/view/plugin/search/search.tsx
+++ b/src/view/plugin/search/search.tsx
@@ -94,7 +94,7 @@ export function Search() {
         aria-label={_('search.placeholder')}
         onInput={debouncedOnInput}
         className={classJoin(className('input'), className('search', 'input'))}
-        value={state?.keyword || ''}
+        defaultValue={state?.keyword || ''}
       />
     </div>
   );


### PR DESCRIPTION
Fixes #1081 by preventing keyword state changes after debounce/search completes from updating the search input value.

Fix is live here: https://moneymarket.fun/
Compared without the fix (type fast): https://8a4e5f66.moneymarket-fun.pages.dev/