### PR TITLE
fix: use relative path for named import

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,7 @@ import Cell from './src/cell';
 import { useConfig } from './src/hooks/useConfig';
 import { useStore } from './src/hooks/useStore';
 import useSelector from './src/hooks/useSelector';
-import { useTranslator } from 'src/i18n/language';
+import { useTranslator } from './src/i18n/language';
 
 export {
   Grid,


### PR DESCRIPTION
This minor change could potentially prevent import errors for typescript 5.