### PR TITLE
fix: gridjs duplicate plugin error when updating config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -164,6 +164,9 @@ export class Config {
       translator: new Translator(config.language),
     });
 
+    // clear existing plugins list to prevent duplicate errors
+    config.plugin = new PluginManager();
+
     if (config.search) {
       // Search
       config.plugin.add({


### PR DESCRIPTION
Resolves: https://github.com/grid-js/gridjs/issues/1291

Issue:
- using `gridjs-react`. When mounting and unmounting the grid component the gridjs complains about duplicate plugins in the config. 
solution:
- clear the config plugin list before adding new ones when updating the config.