### PR TITLE
feat: add ability to initially sort a column descending

### DIFF
--- a/src/view/plugin/sort/sort.tsx
+++ b/src/view/plugin/sort/sort.tsx
@@ -15,6 +15,8 @@ import { useStore } from '../../../hooks/useStore';
 // column specific config
 export interface SortConfig {
   compare?: Comparator<TCell>;
+  // 1 ascending, -1 descending
+  direction?: 1 | -1;
 }
 
 // generic sort config:
@@ -69,6 +71,11 @@ export function Sort(
     if (!currentColumn) {
       setDirection(0);
     } else {
+      // if the direction is not set, initialize the selected
+      // column direction with the passed prop (default to ascending)
+      if (direction === 0) {
+        currentColumn.direction = props.direction ?? 1;
+      }
       setDirection(currentColumn.direction);
     }
   }, [state]);


### PR DESCRIPTION
After playing around with gridJS I noticed there wasn't a way to have columns sort descending on first click. Normally with numbers, this is the way you want sorting to behave (highest numbers first, to lowest). With this addition you can set the direction of the column sort in config.

```js
      columns: ['Name', 'Email', 'Phone Number', {
        name: 'Age',
        sort: {
          direction: -1,
        }}]
```