### PR TITLE
[fix] missing `types` field in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
       "browser": "./dist/gridjs.module.js",
       "umd": "./dist/gridjs.umd.js",
       "import": "./dist/gridjs.mjs",
-      "require": "./dist/gridjs.js"
+      "require": "./dist/gridjs.js",
+      "types": "./dist/index.d.ts"
     },
     "./legacy": {
       "browser": "./dist/gridjs.production.es.min.js",
@@ -49,8 +50,7 @@
       "import": "./plugins/selection/dist/selection.mjs",
       "require": "./plugins/selection/dist/selection.js"
     },
-    "./package.json": "./package.json",
-    "./": "./"
+    "./package.json": "./package.json"
   },
   "main": "dist/gridjs.js",
   "module": "dist/gridjs.module.js",


### PR DESCRIPTION
Installing `gridjs` to a fresh typescript project with configured with `"moduleResolution": "bundler"` fails to resolve types for `gridjs` due to the missing `types` field.  Adding the missing field solves this rather critical problem.  I also removed the invalid entry `"./": "./"`.