### PR TITLE
Fix: "types" added to export parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
       "browser": "./dist/gridjs.module.js",
       "umd": "./dist/gridjs.umd.js",
       "import": "./dist/gridjs.mjs",
-      "require": "./dist/gridjs.js"
+      "require": "./dist/gridjs.js",
+      "types": "./dist/index.d.ts"
     },
     "./legacy": {
       "browser": "./dist/gridjs.production.es.min.js",


### PR DESCRIPTION
While importing the library using `import { Grid } from "gridjs"`, I encountered the following error:

```error TS7016: Could not find a declaration file for module 'gridjs'. '/home/i/dataview-plus/node_modules/gridjs/dist/gridjs.mjs' implicitly has an 'any' type.
  There are types at '/home/i/dataview-plus/node_modules/gridjs/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'gridjs' library may need to update its package.json or typings.
```

Adding 'types' to exports resolved this issue. I must admit that I don't fully understand the root cause, perhaps it's related to TypeScript version differences. Nevertheless, I decided to create a pull request since the change is minimal, and more experienced experts may suggest a more suitable solution.