### PR TITLE
feature: allow searchbox to not autoload and use enter instead

### DIFF
--- a/src/i18n/en_US.ts
+++ b/src/i18n/en_US.ts
@@ -1,6 +1,7 @@
 export default {
   search: {
     placeholder: 'Type a keyword...',
+    button: 'Search',
   },
   sort: {
     sortAsc: 'Sort column ascending',

--- a/src/theme/mermaid/search.scss
+++ b/src/theme/mermaid/search.scss
@@ -1,9 +1,17 @@
+@import 'colors';
+
 .gridjs {
   &-search {
     float: left;
 
     &-input {
       width: 250px;
+    }
+    button, select {
+      padding: 10px 14px;
+      border: 1px solid $gray4;
+      background-color: $white;
+      border-radius: 6px
     }
   }
 }


### PR DESCRIPTION
this PR adds an option to show a button next to the searchbox and adds the ability to allow search by enter key.
if debounceTime is <0, then it does not autosearch

```
search: {
  debounceTime: -1,
  showSearchButton: true,
},
```
