### PR TITLE
Replace sort 'buttons' with spans

### DIFF
--- a/src/theme/mermaid/sort.scss
+++ b/src/theme/mermaid/sort.scss
@@ -1,4 +1,4 @@
-button.gridjs {
+span.gridjs {
   &-sort {
     float: right;
     height: 24px;

--- a/src/view/plugin/sort/sort.tsx
+++ b/src/view/plugin/sort/sort.tsx
@@ -142,7 +142,7 @@ export function Sort(
   };
 
   return (
-    <button
+    <span
       // because the corresponding <th> has tabIndex=0
       tabIndex={-1}
       aria-label={_(`sort.sort${direction === 1 ? 'Desc' : 'Asc'}`)}


### PR DESCRIPTION
With Grid.js, the interactive part of sorting is the entire column heading; however, using the 'button' tag for the sort direction arrows indicates to screen readers that the arrows are the interactive content. Not only is this bad practice, but the arrow elements we use in Grid.js are below the minimum size requirements of WCAG standard 2.5.8 for interactive elements - 24x24 pixels. By changing the indicators from buttons to spans, we stick to the best practice and avoid the WCAG violation with minuscule changes to the code and no conflicts.