### PR TITLE
Fix for #1452

### DIFF
--- a/src/view/table/tbody.tsx
+++ b/src/view/table/tbody.tsx
@@ -37,7 +37,7 @@ export function TBody() {
         />
       )}
 
-      {status === Status.Rendered && data && data.length === 0 && (
+      {(status === Status.Rendered || status === Status.Loaded) && data && data.length === 0 && (
         <MessageRow
           message={_('noRecordsFound')}
           colSpan={headerLength()}


### PR DESCRIPTION
Missing MessageRow "No records found" after call forceRender and where data is empty (tbody is empty).

When calling render the data load ends with "Rendered" status When calling forceRender the data load ends with "Loaded" status instead of "Rendered"

This are two scenarios which we may want to show "No records found", so is added as a valid status to show the MessageRow and now it shows correctly with render and forceRender